### PR TITLE
Fixes an issue where gulp-logwarn would fail if opt wasn't passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(subString, opt) {
 
         var finalMessage = file.path+" ("+m+")\n" + message;
         if (m === 0) {
-          if (opt.logLevel === 'info') {
+          if (opt && opt.logLevel !== 'warn') {
             console.log(finalMessage.green);
           }
         } else {


### PR DESCRIPTION
I made a huge oversight in my original pull request (#4), and forgot to check if `opt` even existed. This PR fixes that.