### PR TITLE
Add fallback for undefined options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var colors = require('colors');
 module.exports = function(subString, opt) {
 
   var substrings = typeof subString === "undefined" ? [] : subString;
+  opt = opt || {};
 
   function occurrences(file,cb){
 


### PR DESCRIPTION
If no option object is passed to logwarn, the script should continue with an empty object instead.
Currently, it fails with 

`TypeError: Cannot read property 'color' of undefined`
